### PR TITLE
hotfix: fix remaining import paths after refactoring

### DIFF
--- a/aurynk/application.py
+++ b/aurynk/application.py
@@ -133,7 +133,7 @@ class AurynkApp(Adw.Application):
         start_tray_helper()
         # Expose a convenience method on the app instance so windows can call
         # `app.send_status_to_tray()` without importing the tray controller.
-        from aurynk.lib.tray_controller import send_status_to_tray
+        from aurynk.services.tray_service import send_status_to_tray
 
         # create a small wrapper that binds the app instance
         self.send_status_to_tray = lambda status=None: send_status_to_tray(self, status)

--- a/aurynk/ui/windows/main_window.py
+++ b/aurynk/ui/windows/main_window.py
@@ -359,7 +359,7 @@ class AurynkWindow(Adw.ApplicationWindow):
 
     def _on_add_device_clicked(self, button):
         """Handle Add Device button click."""
-        from aurynk.dialogs.pairing_dialog import PairingDialog
+        from aurynk.ui.dialogs.pairing_dialog import PairingDialog
 
         dialog = PairingDialog(self)
         dialog.present()


### PR DESCRIPTION
Fixes import errors that were missed during the refactoring:

- `aurynk.lib.tray_controller` → `aurynk.services.tray_service`
- `aurynk.dialogs.pairing_dialog` → `aurynk.ui.dialogs.pairing_dialog`

All imports have been tested and verified.