### PR TITLE
🔒 Fix insecure file permissions for device store

### DIFF
--- a/aurynk/core/device_manager.py
+++ b/aurynk/core/device_manager.py
@@ -163,8 +163,13 @@ class DeviceStore:
         """Save the current list of devices to the JSON file."""
         os.makedirs(os.path.dirname(self.path), exist_ok=True)
         try:
-            with open(self.path, "w") as f:
+            # Create file with 600 permissions (read/write only for owner)
+            fd = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
                 json.dump(self._devices, f, indent=2)
+
+            # Explicitly set permissions in case the file already existed with different permissions
+            os.chmod(self.path, 0o600)
         except Exception as e:
             logger.error(f"Error saving devices: {e}")
         else:

--- a/tests/test_device_manager_security.py
+++ b/tests/test_device_manager_security.py
@@ -41,7 +41,10 @@ class TestDeviceManagerSecurity(unittest.TestCase):
 
         st = os.stat(self.file_path)
         mode = st.st_mode & 0o777
-        self.assertEqual(mode, 0o600, f"File permissions should be updated to 0600, but got {oct(mode)}")
+        self.assertEqual(
+            mode, 0o600, f"File permissions should be updated to 0600, but got {oct(mode)}"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_device_manager_security.py
+++ b/tests/test_device_manager_security.py
@@ -1,0 +1,46 @@
+import os
+import stat
+import unittest
+import shutil
+import tempfile
+from aurynk.core.device_manager import DeviceStore
+
+class TestDeviceManagerSecurity(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.file_path = os.path.join(self.temp_dir, "devices.json")
+        self.store = DeviceStore(self.file_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_file_permissions(self):
+        """Test that the device store file has secure permissions (600)."""
+        self.store.add_or_update_device({"address": "192.168.1.100", "name": "Test Device"})
+
+        # Verify file exists
+        self.assertTrue(os.path.exists(self.file_path))
+
+        # Check permissions
+        st = os.stat(self.file_path)
+        mode = st.st_mode & 0o777
+
+        # Should be 0o600 (rw-------)
+        self.assertEqual(mode, 0o600, f"File permissions should be 0600, but got {oct(mode)}")
+
+    def test_existing_file_permissions_update(self):
+        """Test that an existing file with insecure permissions is updated to 600."""
+        # Create a file with insecure permissions
+        with open(self.file_path, "w") as f:
+            f.write("[]")
+        os.chmod(self.file_path, 0o664)
+
+        # Reload store (or just force save)
+        self.store.add_or_update_device({"address": "192.168.1.101", "name": "Another Device"})
+
+        st = os.stat(self.file_path)
+        mode = st.st_mode & 0o777
+        self.assertEqual(mode, 0o600, f"File permissions should be updated to 0600, but got {oct(mode)}")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_manager_security.py
+++ b/tests/test_device_manager_security.py
@@ -1,9 +1,10 @@
 import os
-import stat
-import unittest
 import shutil
 import tempfile
+import unittest
+
 from aurynk.core.device_manager import DeviceStore
+
 
 class TestDeviceManagerSecurity(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR addresses a security vulnerability where `devices.json` was created with default umask permissions (typically 644), potentially exposing sensitive device data.

**Changes:**
- Modified `DeviceStore._save_to_file` in `aurynk/core/device_manager.py` to use `os.open` with `os.O_WRONLY | os.O_CREAT | os.O_TRUNC` and mode `0o600`.
- Added `os.chmod(self.path, 0o600)` to ensure existing files are updated to secure permissions.
- Added `tests/test_device_manager_security.py` to verify the fix and prevent regressions.

**Verification:**
- Validated with a reproduction script that file permissions are now `0o600`.
- Verified that existing functionality is preserved.
- Ran `tests/test_device_manager_security.py` successfully.

---
*PR created automatically by Jules for task [17834951193328082527](https://jules.google.com/task/17834951193328082527) started by @IshuSinghSE*