### PR TITLE
🧪 Add test for unexpected errors in pairing

### DIFF
--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -56,6 +56,15 @@ class TestPairingManager(unittest.TestCase):
         result = self.pairing_manager.pair_with_code("192.168.1.5", "invalid", "123456")
         self.assertFalse(result)
 
+    @patch("aurynk.core.pairing.subprocess.run")
+    def test_pair_with_code_unexpected_error(self, mock_run):
+        """Test unexpected error during pairing."""
+        mock_run.side_effect = Exception("Generic error")
+
+        result = self.pairing_manager.pair_with_code("192.168.1.5", "5555", "123456")
+
+        self.assertFalse(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
*   🎯 **What:** Add a unit test to `tests/test_pairing.py` to cover unexpected errors during the pairing process.
*   📊 **Coverage:** The test simulates a generic exception in `subprocess.run` and asserts that `pair_with_code` returns `False` without crashing.
*   ✨ **Result:** Improved test coverage and verification of graceful error handling in `PairingManager`.

---
*PR created automatically by Jules for task [1803977091899162778](https://jules.google.com/task/1803977091899162778) started by @IshuSinghSE*