### PR TITLE
⚡ Optimize ADB device specs fetching

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -308,55 +308,7 @@ class ADBController:
             Dict[str, str]: A dictionary containing RAM, storage, and battery info.
         """
         serial = f"{address}:{connect_port}"
-        specs = {"ram": "", "storage": "", "battery": ""}
-
-        try:
-            # RAM
-            timeout = SettingsManager().get("adb", "connection_timeout", 10)
-            meminfo = subprocess.run(
-                [get_adb_path(), "-s", serial, "shell", "cat", "/proc/meminfo"],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            import re
-
-            match = re.search(r"MemTotal:\s+(\d+) kB", meminfo.stdout)
-            if match:
-                ram_mb = int(match.group(1)) // 1000
-                ram_gb = ram_mb / 1000
-                specs["ram"] = f"{round(ram_gb)} GB"
-
-            # Storage
-            df = subprocess.run(
-                [get_adb_path(), "-s", serial, "shell", "df", "/data"],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            lines = df.stdout.splitlines()
-            if len(lines) > 1:
-                parts = lines[1].split()
-                if len(parts) > 1:
-                    storage_mb = int(parts[1]) // 1000
-                    storage_gb = storage_mb / 1000
-                    specs["storage"] = f"{round(storage_gb)} GB"
-
-            # Battery
-            battery = subprocess.run(
-                [get_adb_path(), "-s", serial, "shell", "dumpsys", "battery"],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            match = re.search(r"level: (\d+)", battery.stdout)
-            if match:
-                specs["battery"] = f"{match.group(1)}%"
-
-        except Exception as e:
-            logger.error(f"Error fetching specs: {e}")
-
-        return specs
+        return self._fetch_specs_internal(serial)
 
     def fetch_device_specs_by_serial(self, serial: str) -> Dict[str, str]:
         """
@@ -368,53 +320,67 @@ class ADBController:
         Returns:
             Dict[str, str]: A dictionary containing RAM, storage, and battery info.
         """
+        return self._fetch_specs_internal(serial)
+
+    def _fetch_specs_internal(self, serial: str) -> Dict[str, str]:
+        """
+        Internal method to fetch device specs using a single ADB command.
+        """
         specs = {"ram": "", "storage": "", "battery": ""}
+        split_token = "___AURYNK_SPLIT___"
 
         try:
-            # RAM
+            # Combined command to reduce overhead
+            # cat /proc/meminfo
+            # df /data
+            # dumpsys battery
+            cmd = f'cat /proc/meminfo; echo "{split_token}"; df /data; echo "{split_token}"; dumpsys battery'
+
             timeout = SettingsManager().get("adb", "connection_timeout", 10)
-            meminfo = subprocess.run(
-                [get_adb_path(), "-s", serial, "shell", "cat", "/proc/meminfo"],
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd],
                 capture_output=True,
                 text=True,
                 timeout=timeout,
             )
+
+            output = result.stdout
+            parts = output.split(split_token)
+
             import re
 
-            match = re.search(r"MemTotal:\s+(\d+) kB", meminfo.stdout)
-            if match:
-                ram_mb = int(match.group(1)) // 1000
-                ram_gb = ram_mb / 1000
-                specs["ram"] = f"{round(ram_gb)} GB"
+            # Part 1: RAM
+            if len(parts) > 0:
+                meminfo = parts[0]
+                match = re.search(r"MemTotal:\s+(\d+) kB", meminfo)
+                if match:
+                    ram_mb = int(match.group(1)) // 1000
+                    ram_gb = ram_mb / 1000
+                    specs["ram"] = f"{round(ram_gb)} GB"
 
-            # Storage
-            df = subprocess.run(
-                [get_adb_path(), "-s", serial, "shell", "df", "/data"],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            lines = df.stdout.splitlines()
-            if len(lines) > 1:
-                parts = lines[1].split()
-                if len(parts) > 1:
-                    storage_mb = int(parts[1]) // 1000
-                    storage_gb = storage_mb / 1000
-                    specs["storage"] = f"{round(storage_gb)} GB"
+            # Part 2: Storage
+            if len(parts) > 1:
+                df_out = parts[1]
+                lines = df_out.strip().splitlines()
+                if len(lines) > 1:
+                    parts_line = lines[1].split()
+                    if len(parts_line) > 1:
+                        try:
+                            storage_mb = int(parts_line[1]) // 1000
+                            storage_gb = storage_mb / 1000
+                            specs["storage"] = f"{round(storage_gb)} GB"
+                        except ValueError:
+                            pass
 
-            # Battery
-            battery = subprocess.run(
-                [get_adb_path(), "-s", serial, "shell", "dumpsys", "battery"],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            match = re.search(r"level: (\d+)", battery.stdout)
-            if match:
-                specs["battery"] = f"{match.group(1)}%"
+            # Part 3: Battery
+            if len(parts) > 2:
+                battery_out = parts[2]
+                match = re.search(r"level: (\d+)", battery_out)
+                if match:
+                    specs["battery"] = f"{match.group(1)}%"
 
         except Exception as e:
-            logger.error(f"Error fetching specs by serial: {e}")
+            logger.error(f"Error fetching specs: {e}")
 
         return specs
 

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -109,7 +109,7 @@ def start_udev_subscription(app):
 
 # Debounce mechanism to prevent tray update spam
 _last_tray_update = 0
-_tray_update_lock = __import__("threading").Lock()
+_tray_update_lock = threading.Lock()
 _pending_tray_update = None
 _TRAY_UPDATE_MIN_INTERVAL = 0.2  # Minimum 200ms between tray updates
 

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -110,14 +110,14 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
     def test_fetch_device_specs(self, mock_settings, mock_subprocess_run, mock_get_adb_path):
         mock_settings.return_value.get.return_value = 10
 
-        # meminfo, df, dumpsys battery
-        mock_subprocess_run.side_effect = [
-            MagicMock(stdout="MemTotal:        8000000 kB\n"),
-            MagicMock(
-                stdout="Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/block/dm-0 120000000 10000 110000000 1% /data\n"
-            ),
-            MagicMock(stdout="  level: 85\n"),
-        ]
+        combined_output = (
+            "MemTotal:        8000000 kB\n"
+            "___AURYNK_SPLIT___\n"
+            "Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/block/dm-0 120000000 10000 110000000 1% /data\n"
+            "___AURYNK_SPLIT___\n"
+            "  level: 85\n"
+        )
+        mock_subprocess_run.return_value = MagicMock(stdout=combined_output)
 
         specs = self.adb_controller.fetch_device_specs("192.168.1.5", 5555)
         self.assertEqual(specs["ram"], "8 GB")


### PR DESCRIPTION
💡 **What:**
Optimized `fetch_device_specs` and `fetch_device_specs_by_serial` in `aurynk/core/adb_manager.py` to execute a single ADB shell command instead of three separate commands.

🎯 **Why:**
Previously, fetching device specs required three separate `subprocess.run` calls to `adb shell` (for RAM, storage, and battery), each incurring the overhead of establishing a new ADB connection/session. This was inefficient, especially over slower connections (e.g., wireless ADB).

📊 **Measured Improvement:**
- **Baseline:** 3 `subprocess.run` calls per spec fetch.
- **Optimized:** 1 `subprocess.run` call per spec fetch.
- Verified using a reproduction script (`tests/repro_perf.py`) which confirmed the reduction in calls.
- Existing unit tests were updated to verify the new implementation correctly parses the combined output.

---
*PR created automatically by Jules for task [5874488818103865537](https://jules.google.com/task/5874488818103865537) started by @IshuSinghSE*