### PR TITLE
🧪 Add tests for ADB utility functions

### DIFF
--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -109,7 +109,7 @@ def start_udev_subscription(app):
 
 # Debounce mechanism to prevent tray update spam
 _last_tray_update = 0
-_tray_update_lock = __import__("threading").Lock()
+_tray_update_lock = threading.Lock()
 _pending_tray_update = None
 _TRAY_UPDATE_MIN_INTERVAL = 0.2  # Minimum 200ms between tray updates
 

--- a/tests/test_adb_utils.py
+++ b/tests/test_adb_utils.py
@@ -1,8 +1,15 @@
-import unittest
-from unittest.mock import patch, MagicMock
 import os
 import shlex
-from aurynk.utils.adb_utils import get_adb_path, is_device_connected, clear_device_notifications, send_device_notification
+import unittest
+from unittest.mock import patch
+
+from aurynk.utils.adb_utils import (
+    clear_device_notifications,
+    get_adb_path,
+    is_device_connected,
+    send_device_notification,
+)
+
 
 class TestAdbUtils(unittest.TestCase):
 
@@ -140,7 +147,8 @@ class TestAdbUtils(unittest.TestCase):
     @patch('subprocess.run')
     def test_send_device_notification_failure(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
-        with patch('aurynk.utils.adb_utils.clear_device_notifications') as mock_clear:
+        # We need to patch clear_device_notifications to avoid side effects, even if unused
+        with patch('aurynk.utils.adb_utils.clear_device_notifications'):
              mock_run.return_value.returncode = 1
              result = send_device_notification("serial", "message")
              self.assertFalse(result)

--- a/tests/test_adb_utils.py
+++ b/tests/test_adb_utils.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import shlex
+from aurynk.utils.adb_utils import get_adb_path, is_device_connected, clear_device_notifications, send_device_notification
+
+class TestAdbUtils(unittest.TestCase):
+
+    @patch('aurynk.utils.settings.SettingsManager')
+    def test_get_adb_path_default(self, mock_settings_manager):
+        # Setup mock to return empty
+        mock_settings_manager.return_value.get.return_value = ""
+
+        path = get_adb_path()
+        self.assertEqual(path, "adb")
+
+    @patch('aurynk.utils.settings.SettingsManager')
+    @patch('os.path.isfile')
+    @patch('os.access')
+    def test_get_adb_path_custom(self, mock_access, mock_isfile, mock_settings_manager):
+        custom_path = "/usr/bin/custom_adb"
+        mock_settings_manager.return_value.get.return_value = custom_path
+        mock_isfile.return_value = True
+        mock_access.return_value = True
+
+        path = get_adb_path()
+        self.assertEqual(path, custom_path)
+        mock_isfile.assert_called_with(custom_path)
+        mock_access.assert_called_with(custom_path, os.X_OK)
+
+    @patch('aurynk.utils.settings.SettingsManager')
+    @patch('os.path.isfile')
+    def test_get_adb_path_invalid(self, mock_isfile, mock_settings_manager):
+        custom_path = "/invalid/path"
+        mock_settings_manager.return_value.get.return_value = custom_path
+        mock_isfile.return_value = False
+
+        path = get_adb_path()
+        self.assertEqual(path, "adb")
+
+    @patch('aurynk.utils.settings.SettingsManager')
+    def test_get_adb_path_exception(self, mock_settings_manager):
+        mock_settings_manager.side_effect = Exception("Config error")
+
+        path = get_adb_path()
+        self.assertEqual(path, "adb")
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_is_device_connected_true(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "List of devices attached\n192.168.1.5:5555\tdevice\n"
+
+        result = is_device_connected("192.168.1.5", 5555)
+        self.assertTrue(result)
+        mock_run.assert_called_with(["adb", "devices"], capture_output=True, text=True)
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_is_device_connected_false(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "List of devices attached\n"
+
+        result = is_device_connected("192.168.1.5", 5555)
+        self.assertFalse(result)
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_is_device_connected_offline(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "List of devices attached\n192.168.1.5:5555\toffline\n"
+
+        result = is_device_connected("192.168.1.5", 5555)
+        self.assertFalse(result)
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_is_device_connected_error(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.return_value.returncode = 1
+
+        result = is_device_connected("192.168.1.5", 5555)
+        self.assertFalse(result)
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_is_device_connected_exception(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.side_effect = Exception("ADB error")
+
+        result = is_device_connected("192.168.1.5", 5555)
+        self.assertFalse(result)
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_clear_device_notifications_success(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.return_value.returncode = 0
+
+        result = clear_device_notifications("serial")
+        self.assertTrue(result)
+        mock_run.assert_called_with(
+            ["adb", "-s", "serial", "shell", "cmd notification cancel aurynk_status"],
+            capture_output=True,
+            timeout=2
+        )
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_clear_device_notifications_failure(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.side_effect = Exception("ADB error")
+
+        result = clear_device_notifications("serial")
+        self.assertFalse(result)
+
+    @patch('aurynk.utils.adb_utils.clear_device_notifications')
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_send_device_notification_success(self, mock_run, mock_get_adb_path, mock_clear):
+        mock_get_adb_path.return_value = "adb"
+        mock_run.return_value.returncode = 0
+        mock_clear.return_value = True
+
+        result = send_device_notification("serial", "message", "title")
+        self.assertTrue(result)
+
+        mock_clear.assert_called_with("serial")
+        # Check that subprocess was called with the correct command
+        expected_cmd = f"cmd notification post -S bigtext -t {shlex.quote('title')} aurynk_status {shlex.quote('message')}"
+        mock_run.assert_any_call(
+            ["adb", "-s", "serial", "shell", expected_cmd],
+            capture_output=True, text=True, timeout=3
+        )
+
+    @patch('aurynk.utils.adb_utils.get_adb_path')
+    @patch('subprocess.run')
+    def test_send_device_notification_failure(self, mock_run, mock_get_adb_path):
+        mock_get_adb_path.return_value = "adb"
+        with patch('aurynk.utils.adb_utils.clear_device_notifications') as mock_clear:
+             mock_run.return_value.returncode = 1
+             result = send_device_notification("serial", "message")
+             self.assertFalse(result)

--- a/tests/test_adb_utils.py
+++ b/tests/test_adb_utils.py
@@ -12,8 +12,7 @@ from aurynk.utils.adb_utils import (
 
 
 class TestAdbUtils(unittest.TestCase):
-
-    @patch('aurynk.utils.settings.SettingsManager')
+    @patch("aurynk.utils.settings.SettingsManager")
     def test_get_adb_path_default(self, mock_settings_manager):
         # Setup mock to return empty
         mock_settings_manager.return_value.get.return_value = ""
@@ -21,9 +20,9 @@ class TestAdbUtils(unittest.TestCase):
         path = get_adb_path()
         self.assertEqual(path, "adb")
 
-    @patch('aurynk.utils.settings.SettingsManager')
-    @patch('os.path.isfile')
-    @patch('os.access')
+    @patch("aurynk.utils.settings.SettingsManager")
+    @patch("os.path.isfile")
+    @patch("os.access")
     def test_get_adb_path_custom(self, mock_access, mock_isfile, mock_settings_manager):
         custom_path = "/usr/bin/custom_adb"
         mock_settings_manager.return_value.get.return_value = custom_path
@@ -35,8 +34,8 @@ class TestAdbUtils(unittest.TestCase):
         mock_isfile.assert_called_with(custom_path)
         mock_access.assert_called_with(custom_path, os.X_OK)
 
-    @patch('aurynk.utils.settings.SettingsManager')
-    @patch('os.path.isfile')
+    @patch("aurynk.utils.settings.SettingsManager")
+    @patch("os.path.isfile")
     def test_get_adb_path_invalid(self, mock_isfile, mock_settings_manager):
         custom_path = "/invalid/path"
         mock_settings_manager.return_value.get.return_value = custom_path
@@ -45,15 +44,15 @@ class TestAdbUtils(unittest.TestCase):
         path = get_adb_path()
         self.assertEqual(path, "adb")
 
-    @patch('aurynk.utils.settings.SettingsManager')
+    @patch("aurynk.utils.settings.SettingsManager")
     def test_get_adb_path_exception(self, mock_settings_manager):
         mock_settings_manager.side_effect = Exception("Config error")
 
         path = get_adb_path()
         self.assertEqual(path, "adb")
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_is_device_connected_true(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.return_value.returncode = 0
@@ -63,8 +62,8 @@ class TestAdbUtils(unittest.TestCase):
         self.assertTrue(result)
         mock_run.assert_called_with(["adb", "devices"], capture_output=True, text=True)
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_is_device_connected_false(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.return_value.returncode = 0
@@ -73,8 +72,8 @@ class TestAdbUtils(unittest.TestCase):
         result = is_device_connected("192.168.1.5", 5555)
         self.assertFalse(result)
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_is_device_connected_offline(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.return_value.returncode = 0
@@ -83,8 +82,8 @@ class TestAdbUtils(unittest.TestCase):
         result = is_device_connected("192.168.1.5", 5555)
         self.assertFalse(result)
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_is_device_connected_error(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.return_value.returncode = 1
@@ -92,8 +91,8 @@ class TestAdbUtils(unittest.TestCase):
         result = is_device_connected("192.168.1.5", 5555)
         self.assertFalse(result)
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_is_device_connected_exception(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.side_effect = Exception("ADB error")
@@ -101,8 +100,8 @@ class TestAdbUtils(unittest.TestCase):
         result = is_device_connected("192.168.1.5", 5555)
         self.assertFalse(result)
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_clear_device_notifications_success(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.return_value.returncode = 0
@@ -112,11 +111,11 @@ class TestAdbUtils(unittest.TestCase):
         mock_run.assert_called_with(
             ["adb", "-s", "serial", "shell", "cmd notification cancel aurynk_status"],
             capture_output=True,
-            timeout=2
+            timeout=2,
         )
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_clear_device_notifications_failure(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         mock_run.side_effect = Exception("ADB error")
@@ -124,9 +123,9 @@ class TestAdbUtils(unittest.TestCase):
         result = clear_device_notifications("serial")
         self.assertFalse(result)
 
-    @patch('aurynk.utils.adb_utils.clear_device_notifications')
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.clear_device_notifications")
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_send_device_notification_success(self, mock_run, mock_get_adb_path, mock_clear):
         mock_get_adb_path.return_value = "adb"
         mock_run.return_value.returncode = 0
@@ -140,15 +139,17 @@ class TestAdbUtils(unittest.TestCase):
         expected_cmd = f"cmd notification post -S bigtext -t {shlex.quote('title')} aurynk_status {shlex.quote('message')}"
         mock_run.assert_any_call(
             ["adb", "-s", "serial", "shell", expected_cmd],
-            capture_output=True, text=True, timeout=3
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
 
-    @patch('aurynk.utils.adb_utils.get_adb_path')
-    @patch('subprocess.run')
+    @patch("aurynk.utils.adb_utils.get_adb_path")
+    @patch("subprocess.run")
     def test_send_device_notification_failure(self, mock_run, mock_get_adb_path):
         mock_get_adb_path.return_value = "adb"
         # We need to patch clear_device_notifications to avoid side effects, even if unused
-        with patch('aurynk.utils.adb_utils.clear_device_notifications'):
-             mock_run.return_value.returncode = 1
-             result = send_device_notification("serial", "message")
-             self.assertFalse(result)
+        with patch("aurynk.utils.adb_utils.clear_device_notifications"):
+            mock_run.return_value.returncode = 1
+            result = send_device_notification("serial", "message")
+            self.assertFalse(result)


### PR DESCRIPTION
Added comprehensive unit tests for `aurynk/utils/adb_utils.py`, covering `get_adb_path`, `is_device_connected`, and notification functions. The tests use `unittest.mock` to simulate ADB responses and settings configurations, ensuring robust coverage without external dependencies. Confirmed that new tests pass and existing tests (where environment permits) are unaffected.

---
*PR created automatically by Jules for task [6722681576692388981](https://jules.google.com/task/6722681576692388981) started by @IshuSinghSE*