### PR TITLE
fix: Prevent command injection via malicious package names in ADBController

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -12,7 +12,7 @@ from zeroconf import IPVersion, ServiceBrowser, ServiceStateChange, Zeroconf
 
 from aurynk.core.device_manager import DeviceStore
 from aurynk.i18n import _
-from aurynk.utils.adb_utils import get_adb_path
+from aurynk.utils.adb_utils import get_adb_path, is_valid_package_name
 from aurynk.utils.logger import get_logger
 from aurynk.utils.settings import SettingsManager
 
@@ -510,10 +510,14 @@ class ADBController:
             )
 
             # 5. Return to previous app if possible
-            if current_app:
+            if current_app and is_valid_package_name(current_app):
                 subprocess.run(
                     [get_adb_path(), "-s", serial, "shell", "monkey", "-p", current_app, "1"],
                     timeout=timeout,
+                )
+            elif current_app:
+                logger.warning(
+                    f"Skipping return to previous app: invalid package name '{current_app}'"
                 )
 
             # 6. Pull to local temp directory
@@ -613,10 +617,14 @@ class ADBController:
             )
 
             # Return to previous app if possible
-            if current_app:
+            if current_app and is_valid_package_name(current_app):
                 subprocess.run(
                     [get_adb_path(), "-s", serial, "shell", "monkey", "-p", current_app, "1"],
                     timeout=timeout,
+                )
+            elif current_app:
+                logger.warning(
+                    f"Skipping return to previous app: invalid package name '{current_app}'"
                 )
 
             # Pull to local directory

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -840,3 +840,4 @@ def tray_unpair_device(app, address):
     win.adb_controller.device_store.remove_device(address)
     win._refresh_device_list()
     send_status_to_tray(app)
+    # Ensure tray status is updated

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/aurynk/utils/adb_utils.py
+++ b/aurynk/utils/adb_utils.py
@@ -15,6 +15,18 @@ def get_adb_path():
     return "adb"
 
 
+def is_valid_package_name(package_name: str) -> bool:
+    """Check if a string is a valid Android package name."""
+    if not package_name or len(package_name) > 255:
+        return False
+    import re
+
+    # Basic validation: alphanumeric, underscore, dot.
+    # Disallow spaces, semicolons, and other shell metacharacters.
+    pattern = r"^[a-zA-Z0-9_.]+$"
+    return re.match(pattern, package_name) is not None
+
+
 def is_device_connected(address, connect_port):
     """Check if a device is connected via adb."""
     import subprocess

--- a/tests/test_adb_injection.py
+++ b/tests/test_adb_injection.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from aurynk.core.adb_manager import ADBController
+
+
+class TestADBInjection(unittest.TestCase):
+    @patch("aurynk.core.adb_manager.DeviceStore")
+    def setUp(self, mock_device_store):
+        self.adb_controller = ADBController()
+
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
+    @patch("os.makedirs")
+    @patch("os.path.exists", return_value=False)
+    def test_capture_screenshot_injection(
+        self, mock_exists, mock_makedirs, mock_settings, mock_subprocess_run, mock_get_adb_path
+    ):
+        mock_settings.return_value.get.return_value = 10
+
+        # Malicious package name
+        malicious_app = "com.example;reboot"
+
+        # 1. dumpsys window (screen state) - assume on
+        # 2. dumpsys window windows (keyguard) - assume unlocked
+        # 3. dumpsys window windows (current app) - RETURN MALICIOUS APP
+        # 4. input keyevent 3 (home)
+        # 5. screencap
+        # 6. monkey (restore app) -> THIS IS THE VULNERABLE CALL
+        # 7. pull
+
+        mock_subprocess_run.side_effect = [
+            MagicMock(stdout="mScreenOn=true mInteractive=true"),  # 1
+            MagicMock(stdout="mShowingLockscreen=false"),  # 2
+            MagicMock(
+                stdout=f"mCurrentFocus=Window{{... {malicious_app}/com.example.app.MainActivity}}"
+            ),  # 3
+            MagicMock(returncode=0),  # 4
+            MagicMock(returncode=0),  # 5
+            MagicMock(returncode=0),  # 6
+            MagicMock(returncode=0),  # 7
+        ]
+
+        try:
+            self.adb_controller.capture_screenshot("192.168.1.5", 5555)
+        except Exception as e:
+            print(f"Exception: {e}")
+
+        # Check if the malicious command was passed to subprocess.run
+        # We are looking for the call to monkey
+        # [get_adb_path(), "-s", serial, "shell", "monkey", "-p", current_app, "1"]
+
+        found_vulnerable_call = False
+        for call in mock_subprocess_run.call_args_list:
+            args, _ = call
+            cmd_list = args[0]
+            if "monkey" in cmd_list and malicious_app in cmd_list:
+                found_vulnerable_call = True
+                break
+
+        self.assertFalse(
+            found_vulnerable_call,
+            "Vulnerable subprocess call FOUND! Command injection is possible.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes a potential command injection vulnerability in `capture_screenshot` and `capture_screenshot_by_serial` methods in `ADBController`.

The issue was that `current_app` (retrieved from `dumpsys window`) was used directly in an `adb shell monkey` command without validation. A malicious app could potentially spoof the window focus string to inject shell commands.

Changes:
- Added `is_valid_package_name` helper in `aurynk/utils/adb_utils.py` that enforces a strict allowlist (alphanumeric, dots, underscores).
- Updated `aurynk/core/adb_manager.py` to validate `current_app` before using it. If invalid, the app restoration step is skipped and a warning is logged.
- Added regression test `tests/test_adb_injection.py`.

---
*PR created automatically by Jules for task [17050242429504082413](https://jules.google.com/task/17050242429504082413) started by @IshuSinghSE*