### PR TITLE
🧹 Fix duplicate code in MainWindow initialization

### DIFF
--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/aurynk/ui/windows/main_window.py
+++ b/aurynk/ui/windows/main_window.py
@@ -112,22 +112,6 @@ class AurynkWindow(Adw.ApplicationWindow):
                     except Exception:
                         logger.debug("Failed creating UI row for cached USB device %s", usn)
         except Exception:
-            pass
-        # If we have cached usb_rows data create corresponding UI rows now
-        try:
-            if self.usb_rows:
-                for usn, entry in list(self.usb_rows.items()):
-                    try:
-                        if isinstance(entry, dict) and "data" in entry and "row" not in entry:
-                            dev_data = entry["data"]
-                            # Create a UI row from data (do not call adb here)
-                            row = self._create_device_row(dev_data, is_usb=True)
-                            self.usb_group.add(row)
-                            entry["row"] = row
-                            self.usb_group.set_visible(True)
-                    except Exception:
-                        logger.debug("Failed creating UI row for cached USB device %s", usn)
-        except Exception:
             logger.debug("Error applying cached USB devices at window init", exc_info=True)
 
         # Register for device change events


### PR DESCRIPTION
🎯 **What:** Removed a duplicate code block in `aurynk/ui/windows/main_window.py` responsible for initializing USB device rows from cached data.

💡 **Why:** The code block was copy-pasted twice. The second block had better error logging, so the first redundant block was removed to clean up the code and avoid confusion.

✅ **Verification:**
- Validated syntax with `py_compile`.
- Ran existing tests (`test_pairing.py`, `test_scrcpy_runner.py`) which passed.
- Verified that `test_usb_monitor.py` failures are pre-existing and unrelated to this change.
- Manual review confirmed the logic is identical and safe to remove.

✨ **Result:** Codebase is cleaner with no functional changes.

---
*PR created automatically by Jules for task [6916218210423029636](https://jules.google.com/task/6916218210423029636) started by @IshuSinghSE*