### PR TITLE
⚡ Bolt: Batch ADB getprop calls for faster device info fetching

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,61 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        marketname = ""
+        model = ""
+        manufacturer = ""
+        android_version = ""
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+
+            # Optimization: Batch getprop calls into a single adb shell command
+            # Using a unique delimiter to separate outputs safely
+            delimiter = "AURYNK_DELIMITER_v1"
+            props = [
+                "ro.product.marketname",
+                "ro.product.device",
+                "ro.product.manufacturer",
+                "ro.build.version.release",
+            ]
+
+            # Construct command: "getprop p1; echo DELIM; getprop p2; echo DELIM; ..."
+            shell_cmd = f"; echo {delimiter}; ".join([f"getprop {p}" for p in props])
+
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", shell_cmd],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode == 0:
+                # Split by delimiter and strip whitespace
+                parts = result.stdout.split(delimiter)
+                # Clean up parts (strip whitespace)
+                values = [p.strip() for p in parts]
+
+                # Ensure we have enough values (in case output was truncated)
+                if len(values) >= 4:
+                    marketname = values[0]
+                    model = values[1]
+                    manufacturer = values[2]
+                    android_version = values[3]
+                else:
+                    logger.warning(f"Incomplete device info from batch query: {values}")
+                    # Fallback could be implemented here if needed, but incomplete info is acceptable
+                    # mapping safely
+                    if len(values) > 0:
+                        marketname = values[0]
+                    if len(values) > 1:
+                        model = values[1]
+                    if len(values) > 2:
+                        manufacturer = values[2]
+                    if len(values) > 3:
+                        android_version = values[3]
+
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -349,8 +349,6 @@ def send_devices_to_tray(devices):
         def is_device_connected(a, p):
             return False
 
-    from aurynk.core.scrcpy_runner import ScrcpyManager
-
     scrcpy = ScrcpyManager()
     # Try to get helper process list
     helper_processes = {}

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -150,7 +150,8 @@ def send_status_to_tray(app, status: str = None):
             # Schedule new update after the minimum interval
             delay_ms = int((_TRAY_UPDATE_MIN_INTERVAL - time_since_last) * 1000) + 50
             logger.debug(
-                f"Scheduling delayed tray update in {delay_ms}ms (last update {time_since_last:.3f}s ago)"
+                f"Scheduling delayed tray update in {delay_ms}ms"
+                f" (last update {time_since_last:.3f}s ago)"
             )
             _pending_tray_update = GLib.timeout_add(delay_ms, lambda: _do_tray_update(app, status))
             return
@@ -231,7 +232,8 @@ def _do_tray_update(app, status: str = None):
                         else:
                             mirroring = scrcpy.is_mirroring(address, connect_port)
                         logger.debug(
-                            f"Wireless {address}:{connect_port}: connected={connected}, mirroring={mirroring}, processes={list(scrcpy.processes.keys())}"
+                            f"Wireless {address}:{connect_port}: connected={connected}, "
+                            f"mirroring={mirroring}, processes={list(scrcpy.processes.keys())}"
                         )
 
                     device_status.append(
@@ -295,7 +297,8 @@ def _do_tray_update(app, status: str = None):
                             else:
                                 mirroring = scrcpy.is_mirroring_serial(adb_serial)
                             logger.debug(
-                                f"USB Device {adb_serial}: mirroring={mirroring}, processes={list(scrcpy.processes.keys())}"
+                                f"USB Device {adb_serial}: mirroring={mirroring}, "
+                                f"processes={list(scrcpy.processes.keys())}"
                             )
                             device_status.append(
                                 {

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -174,9 +174,7 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
     @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
     @patch("subprocess.run")
     @patch("aurynk.core.adb_manager.SettingsManager")
-    def test_fetch_device_info_batched(
-        self, mock_settings, mock_subprocess_run, mock_get_adb_path
-    ):
+    def test_fetch_device_info_batched(self, mock_settings, mock_subprocess_run, mock_get_adb_path):
         mock_settings.return_value.get.return_value = 10
 
         # Mock successful output with delimiter
@@ -189,9 +187,7 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
         ]
         mock_stdout = f"\n{delimiter}\n".join(output_values) + "\n"
 
-        mock_subprocess_run.return_value = MagicMock(
-            returncode=0, stdout=mock_stdout, stderr=""
-        )
+        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=mock_stdout, stderr="")
 
         info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -171,6 +171,52 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
         path = self.adb_controller.capture_screenshot("192.168.1.5", 5555)
         self.assertIsNone(path)
 
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
+    def test_fetch_device_info_batched(
+        self, mock_settings, mock_subprocess_run, mock_get_adb_path
+    ):
+        mock_settings.return_value.get.return_value = 10
+
+        # Mock successful output with delimiter
+        delimiter = "AURYNK_DELIMITER_v1"
+        output_values = [
+            "My Market Name",
+            "My Device Model",
+            "My Manufacturer",
+            "13.0",
+        ]
+        mock_stdout = f"\n{delimiter}\n".join(output_values) + "\n"
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0, stdout=mock_stdout, stderr=""
+        )
+
+        info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
+
+        self.assertEqual(info["name"], "My Market Name")
+        self.assertEqual(info["model"], "My Device Model")
+        self.assertEqual(info["manufacturer"], "My Manufacturer")
+        self.assertEqual(info["android_version"], "13.0")
+
+        # Verify subprocess was called ONCE
+        self.assertEqual(mock_subprocess_run.call_count, 1)
+
+        # Verify the command structure contains our delimiter and getprop
+        call_args = mock_subprocess_run.call_args
+        cmd_list = call_args[0][0]
+        self.assertIn("adb", cmd_list)
+        self.assertIn("shell", cmd_list)
+        # The shell command is one of the arguments
+        shell_cmd = None
+        for arg in cmd_list:
+            if delimiter in arg:
+                shell_cmd = arg
+                break
+        self.assertIsNotNone(shell_cmd)
+        self.assertIn("getprop ro.product.marketname", shell_cmd)
+
     def test_load_paired_devices(self):
         self.adb_controller.device_store.get_devices.return_value = [{"name": "Test"}]
         devices = self.adb_controller.load_paired_devices()


### PR DESCRIPTION
⚡ Bolt: Batch ADB getprop calls for faster device info fetching

💡 What:
Replaced 4 sequential `adb shell getprop` calls in `_fetch_device_info` with a single batched `adb shell` command using a delimiter.

🎯 Why:
Each `subprocess.run` call invoking `adb` incurs overhead (connection handshake, process creation). During device pairing/connection, this happens 4 times sequentially to get device details, causing a noticeable delay.

📊 Impact:
Reduces the number of subprocess calls from 4 to 1 for this operation. Assuming ~50-100ms per ADB call, this saves ~150-300ms per connection, making the UI feel snappier.

🔬 Measurement:
A new unit test `test_fetch_device_info_batched` was added to `tests/test_adb_manager.py` which mocks `subprocess.run` and asserts that it is called exactly once instead of 4 times.


---
*PR created automatically by Jules for task [6260763905341271447](https://jules.google.com/task/6260763905341271447) started by @IshuSinghSE*