### PR TITLE
⚡ Bolt: Batch ADB getprop calls for device info

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,39 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        # Batch properties fetch to reduce subprocess overhead (4 calls -> 1 call)
+        # Using a delimiter that is unlikely to be in the property values
+        delimiter = "AURYNK_DELIMITER_v1"
+        cmd_str = (
+            f"getprop ro.product.marketname; echo '{delimiter}'; "
+            f"getprop ro.product.device; echo '{delimiter}'; "
+            f"getprop ro.product.manufacturer; echo '{delimiter}'; "
+            f"getprop ro.build.version.release"
+        )
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+        marketname = ""
+        model = ""
+        manufacturer = ""
+        android_version = ""
+
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode == 0:
+                parts = result.stdout.strip().split(delimiter)
+                if len(parts) >= 4:
+                    marketname = parts[0].strip()
+                    model = parts[1].strip()
+                    manufacturer = parts[2].strip()
+                    android_version = parts[3].strip()
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -1,5 +1,11 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock zeroconf before any imports that might need it
+sys.modules["zeroconf"] = MagicMock()
+
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from aurynk.core.adb_manager import ADBController
 


### PR DESCRIPTION
💡 **What:** Batched multiple `adb shell getprop` calls into a single command in `ADBController._fetch_device_info`.
🎯 **Why:** To reduce the overhead of spawning multiple subprocesses when fetching device details, which happens during pairing and connection.
📊 **Impact:** Reduces subprocess calls from 4 to 1 for this operation, improving responsiveness.
🔬 **Measurement:** Verified with a reproduction script that call count dropped from 4 to 1 while preserving data correctness. Regression tests passed.


---
*PR created automatically by Jules for task [17676541608022355022](https://jules.google.com/task/17676541608022355022) started by @IshuSinghSE*