### PR TITLE
⚡ Bolt: Optimize ADB device info fetching

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,45 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        # Fetch properties in a single batch to reduce overhead
+        delimiter = "AURYNK_DELIMITER_v1"
+        props = [
+            "ro.product.marketname",
+            "ro.product.device",
+            "ro.product.manufacturer",
+            "ro.build.version.release",
+        ]
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+        # Construct command: echo "$(getprop p1)DELIMITER$(getprop p2)..."
+        # We use quotes to preserve spaces in property values.
+        cmd_parts = [f"$(getprop {p})" for p in props]
+        cmd_str = f'echo "{delimiter.join(cmd_parts)}"'
+
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode == 0:
+                # Split by delimiter
+                parts = result.stdout.strip().split(delimiter)
+                # Pad with empty strings if fewer parts returned
+                parts += [""] * (len(props) - len(parts))
+
+                marketname = parts[0].strip()
+                model = parts[1].strip()
+                manufacturer = parts[2].strip()
+                android_version = parts[3].strip()
+            else:
+                marketname = model = manufacturer = android_version = ""
+
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
+            marketname = model = manufacturer = android_version = ""
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -186,6 +186,36 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
         self.adb_controller.remove_device("192.168.1.5")
         self.adb_controller.device_store.remove_device.assert_called_once_with("192.168.1.5")
 
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
+    def test_fetch_device_info_optimized(
+        self, mock_settings, mock_subprocess_run, mock_get_adb_path
+    ):
+        mock_settings.return_value.get.return_value = 10
+
+        # Mock responses for the single batched call
+        delimiter = "AURYNK_DELIMITER_v1"
+        output = f"MyMarketName{delimiter}MyModel{delimiter}MyManufacturer{delimiter}12\n"
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=output, stderr="")
+
+        info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
+
+        self.assertEqual(info["name"], "MyMarketName")
+        self.assertEqual(info["model"], "MyModel")
+        self.assertEqual(info["manufacturer"], "MyManufacturer")
+        self.assertEqual(info["android_version"], "12")
+
+        # Verify 1 call was made
+        self.assertEqual(mock_subprocess_run.call_count, 1)
+
+        call_args = mock_subprocess_run.call_args[0][0]
+        # Check that one of the arguments contains the delimiter
+        cmd_arg = next((arg for arg in call_args if delimiter in arg), None)
+        self.assertIsNotNone(cmd_arg)
+        self.assertIn("ro.product.marketname", cmd_arg)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
⚡ Bolt: Optimize ADB device info fetching

💡 What: Batched 4 separate `adb shell getprop` calls into a single `adb shell` command using a delimiter-based echo approach.
🎯 Why: Spawning multiple subprocesses for basic device info is inefficient and slow, especially when connecting to multiple devices.
📊 Impact: Reduces process creation overhead by 75% for this specific operation (1 call vs 4 calls).
🔬 Measurement: Verified with a new unit test `test_fetch_device_info_optimized` that ensures the single command returns the correct parsed data.


---
*PR created automatically by Jules for task [3652565609666348893](https://jules.google.com/task/3652565609666348893) started by @IshuSinghSE*