### PR TITLE
⚡ Bolt: Optimize device info fetching by batching ADB calls

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,47 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+            # Batch command to fetch all properties at once
+            delimiter = "AURYNK_DELIMITER_v1"
+            props = [
+                "ro.product.marketname",
+                "ro.product.device",
+                "ro.product.manufacturer",
+                "ro.build.version.release",
+            ]
+
+            # Construct command: getprop p1; echo DELIM; getprop p2; echo DELIM; ...
+            command_str = f"; echo {delimiter}; ".join([f"getprop {p}" for p in props])
+
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", command_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode == 0:
+                parts = result.stdout.split(delimiter)
+                # Clean up whitespace
+                parts = [p.strip() for p in parts]
+
+                # Assign values with bounds checking
+                marketname = parts[0] if len(parts) > 0 else ""
+                model = parts[1] if len(parts) > 1 else ""
+                manufacturer = parts[2] if len(parts) > 2 else ""
+                android_version = parts[3] if len(parts) > 3 else ""
+            else:
+                logger.warning(
+                    f"Failed to fetch device info for {serial}: return code {result.returncode}"
+                )
+                marketname = model = manufacturer = android_version = ""
+
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
+            marketname = model = manufacturer = android_version = ""
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -197,9 +197,7 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
         delimiter = "AURYNK_DELIMITER_v1"
         # Simulate batched output
         # Format: value1\nDELIM\nvalue2\nDELIM...
-        output = (
-            f"MyMarketName\n{delimiter}\nPixel 5\n{delimiter}\nGoogle\n{delimiter}\n12\n"
-        )
+        output = f"MyMarketName\n{delimiter}\nPixel 5\n{delimiter}\nGoogle\n{delimiter}\n12\n"
 
         mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=output)
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -186,6 +186,37 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
         self.adb_controller.remove_device("192.168.1.5")
         self.adb_controller.device_store.remove_device.assert_called_once_with("192.168.1.5")
 
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
+    def test_fetch_device_info_batching(
+        self, mock_settings, mock_subprocess_run, mock_get_adb_path
+    ):
+        mock_settings.return_value.get.return_value = 10
+
+        delimiter = "AURYNK_DELIMITER_v1"
+        # Simulate batched output
+        # Format: value1\nDELIM\nvalue2\nDELIM...
+        output = (
+            f"MyMarketName\n{delimiter}\nPixel 5\n{delimiter}\nGoogle\n{delimiter}\n12\n"
+        )
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=output)
+
+        info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
+
+        self.assertEqual(info["name"], "MyMarketName")
+        self.assertEqual(info["model"], "Pixel 5")
+        self.assertEqual(info["manufacturer"], "Google")
+        self.assertEqual(info["android_version"], "12")
+
+        # Verify only 1 call was made
+        self.assertEqual(mock_subprocess_run.call_count, 1)
+
+        # Verify the command contains the delimiter
+        args, _ = mock_subprocess_run.call_args
+        self.assertIn(delimiter, args[0][4])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
💡 What: Replaced 4 sequential `adb shell getprop` calls in `ADBController._fetch_device_info` with a single batched command using delimiters.
🎯 Why: Each `adb shell` invocation spawns a new process and establishes a new connection, which is expensive. This optimization reduces the overhead from 4N to 1N, speeding up device connection and info retrieval.
📊 Impact: Reduces subprocess creation overhead by 75% for this operation.
🔬 Measurement: Verified with `tests/test_adb_manager.py` which now asserts that `subprocess.run` is called only once for fetching device info.

---
*PR created automatically by Jules for task [8049442539704816149](https://jules.google.com/task/8049442539704816149) started by @IshuSinghSE*