### PR TITLE
⚡ Bolt: Batch ADB getprop calls in _fetch_device_info

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,49 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        # Combined command to fetch all properties at once.
+        # This reduces the number of subprocess calls from 4 to 1.
+        delimiter = "AURYNK_DELIMITER_v1"
+        props = [
+            "ro.product.marketname",
+            "ro.product.device",
+            "ro.product.manufacturer",
+            "ro.build.version.release",
+        ]
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+        # We use a unique delimiter to separate the outputs of each getprop command.
+        # This allows us to parse the result reliably even if some properties are empty or multi-line.
+        cmd_str = f"; echo '{delimiter}'; ".join([f"getprop {p}" for p in props])
+
+        marketname, model, manufacturer, android_version = "", "", "", ""
+
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode == 0:
+                output = result.stdout
+                parts = output.split(delimiter)
+                # Cleanup: split includes the delimiter itself if not careful, but here
+                # split("del") gives parts between delimiters.
+                # cmd: p1; echo del; p2; echo del; p3; echo del; p4
+                # output: val1\n del\n val2\n del\n val3\n del\n val4\n
+                # split(del): [val1\n, \n val2\n, \n val3\n, \n val4\n]
+
+                # Check how many parts we got
+                if len(parts) >= 4:
+                    marketname = parts[0].strip()
+                    model = parts[1].strip()
+                    manufacturer = parts[2].strip()
+                    android_version = parts[3].strip()
+
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -189,13 +189,13 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
     @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
     @patch("subprocess.run")
     @patch("aurynk.core.adb_manager.SettingsManager")
-    def test_fetch_device_info(
-        self, mock_settings, mock_subprocess_run, mock_get_adb_path
-    ):
+    def test_fetch_device_info(self, mock_settings, mock_subprocess_run, mock_get_adb_path):
         mock_settings.return_value.get.return_value = 10
 
         delimiter = "AURYNK_DELIMITER_v1"
-        output_str = f"MyMarketName\n{delimiter}\nMyDevice\n{delimiter}\nMyManufacturer\n{delimiter}\n12\n"
+        output_str = (
+            f"MyMarketName\n{delimiter}\nMyDevice\n{delimiter}\nMyManufacturer\n{delimiter}\n12\n"
+        )
 
         mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=output_str)
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -186,6 +186,33 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
         self.adb_controller.remove_device("192.168.1.5")
         self.adb_controller.device_store.remove_device.assert_called_once_with("192.168.1.5")
 
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
+    def test_fetch_device_info(
+        self, mock_settings, mock_subprocess_run, mock_get_adb_path
+    ):
+        mock_settings.return_value.get.return_value = 10
+
+        delimiter = "AURYNK_DELIMITER_v1"
+        output_str = f"MyMarketName\n{delimiter}\nMyDevice\n{delimiter}\nMyManufacturer\n{delimiter}\n12\n"
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=output_str)
+
+        info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
+
+        self.assertEqual(info["name"], "MyMarketName")
+        self.assertEqual(info["model"], "MyDevice")
+        self.assertEqual(info["manufacturer"], "MyManufacturer")
+        self.assertEqual(info["android_version"], "12")
+
+        # Verify single call with chained command
+        mock_subprocess_run.assert_called_once()
+        args = mock_subprocess_run.call_args[0][0]
+        self.assertIn("adb", args)
+        self.assertIn("shell", args)
+        self.assertIn(delimiter, args[-1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
💡 **What:**
Optimized `ADBController._fetch_device_info` to fetch all device properties (marketname, model, manufacturer, version) in a single `adb shell` execution instead of four separate subprocess calls.

🎯 **Why:**
Each `subprocess.run` call invoking `adb` incurs overhead from process creation and ADB server communication. During device discovery and pairing, minimizing these calls improves responsiveness and reduces the chance of timeout or race conditions.

📊 **Impact:**
- Reduces the number of `adb shell` commands for fetching device info by 75% (from 4 to 1).
- Improves the speed of the "Pair Device" flow and device details loading.

🔬 **Measurement:**
Verified with a new unit test `test_fetch_device_info` in `tests/test_adb_manager.py` which asserts that `subprocess.run` is called exactly once with the correct chained command string. Existing tests were also run to ensure no regressions.

---
*PR created automatically by Jules for task [2765450734249153060](https://jules.google.com/task/2765450734249153060) started by @IshuSinghSE*