### PR TITLE
⚡ Bolt: Batch ADB device info fetch

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,57 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        try:
+            # Optimize: Fetch all properties in a single ADB call using a delimiter
+            # This reduces the overhead of establishing 4 separate ADB shell connections
+            delimiter = "AURYNK_DELIMITER_v1"
+            props = [
+                "ro.product.marketname",
+                "ro.product.device",
+                "ro.product.manufacturer",
+                "ro.build.version.release",
+            ]
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+            # Construct command: "getprop p1; echo DEL; getprop p2; echo DEL..."
+            cmd_parts = []
+            for prop in props:
+                cmd_parts.append(f"getprop {prop}")
+                cmd_parts.append(f"echo {delimiter}")
+
+            # Remove the last echo delimiter to avoid trailing empty part (optional but cleaner)
+            if cmd_parts:
+                cmd_parts.pop()
+
+            cmd_str = "; ".join(cmd_parts)
+
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode == 0:
+                parts = result.stdout.split(delimiter)
+                # Clean up results
+                parts = [p.strip() for p in parts]
+
+                # Ensure we have enough parts (pad with empty strings if needed)
+                while len(parts) < len(props):
+                    parts.append("")
+
+                marketname = parts[0]
+                model = parts[1]
+                manufacturer = parts[2]
+                android_version = parts[3]
+            else:
+                logger.warning(f"Failed to fetch device info in batch: {result.stderr}")
+                marketname, model, manufacturer, android_version = "", "", "", ""
+
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
+            marketname, model, manufacturer, android_version = "", "", "", ""
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -1,5 +1,12 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock zeroconf before import
+mock_zeroconf = MagicMock()
+sys.modules["zeroconf"] = mock_zeroconf
+
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from aurynk.core.adb_manager import ADBController
 
@@ -185,6 +192,40 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
     def test_remove_device(self):
         self.adb_controller.remove_device("192.168.1.5")
         self.adb_controller.device_store.remove_device.assert_called_once_with("192.168.1.5")
+
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
+    def test_fetch_device_info_batch(
+        self, mock_settings_manager, mock_subprocess_run, mock_get_adb_path
+    ):
+        """Test that _fetch_device_info uses a single batched ADB call."""
+        mock_settings_manager.return_value.get.return_value = 10
+
+        delimiter = "AURYNK_DELIMITER_v1"
+        # Simulate combined output: marketname, device, manufacturer, version
+        combined_output = f"MyMarketName\n{delimiter}\nMyDevice\n{delimiter}\nMyManufacturer\n{delimiter}\n12\n"
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0, stdout=combined_output, stderr=""
+        )
+
+        # Call the private method directly for testing
+        info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
+
+        # Verify results
+        self.assertEqual(info["name"], "MyMarketName")
+        self.assertEqual(info["model"], "MyDevice")
+        self.assertEqual(info["manufacturer"], "MyManufacturer")
+        self.assertEqual(info["android_version"], "12")
+
+        # Verify only 1 call was made
+        self.assertEqual(mock_subprocess_run.call_count, 1)
+        args, _ = mock_subprocess_run.call_args
+        cmd_str = args[0][-1]  # The shell command string
+        self.assertIn(delimiter, cmd_str)
+        self.assertIn("getprop ro.product.marketname", cmd_str)
+        self.assertIn("getprop ro.product.device", cmd_str)
 
 
 if __name__ == "__main__":

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -204,7 +204,9 @@ other-device._adb-tls-connect._tcp  192.168.1.6:6666
 
         delimiter = "AURYNK_DELIMITER_v1"
         # Simulate combined output: marketname, device, manufacturer, version
-        combined_output = f"MyMarketName\n{delimiter}\nMyDevice\n{delimiter}\nMyManufacturer\n{delimiter}\n12\n"
+        combined_output = (
+            f"MyMarketName\n{delimiter}\nMyDevice\n{delimiter}\nMyManufacturer\n{delimiter}\n12\n"
+        )
 
         mock_subprocess_run.return_value = MagicMock(
             returncode=0, stdout=combined_output, stderr=""


### PR DESCRIPTION
⚡ Bolt: Batch ADB device info fetch

💡 What:
Optimized `ADBController._fetch_device_info` to fetch all device properties (marketname, model, manufacturer, version) in a single `adb shell` command instead of 4 separate calls.

🎯 Why:
Each `adb shell` command involves process creation and ADB protocol handshake, which introduces significant latency (often 50-100ms per call). Fetching device info is a blocking operation during pairing and discovery; reducing this from 4 calls to 1 improves responsiveness.

📊 Impact:
- Reduces `adb shell` invocations for device info by 75% (4 -> 1).
- Expected latency reduction of ~150-300ms per device fetch.

🔬 Measurement:
- Verified via `tests/test_adb_manager.py` with a new test case `test_fetch_device_info_batch` asserting only 1 `subprocess.run` call is made.

---
*PR created automatically by Jules for task [14564975429744086421](https://jules.google.com/task/14564975429744086421) started by @IshuSinghSE*