### PR TITLE
⚡ Bolt: Batch ADB getprop calls for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Journal
+
+## 2026-02-26 - [ADB Command Batching]
+**Learning:** `subprocess.run` overhead adds up quickly in Python.
+**Action:** Always batch sequential ADB commands using delimiters (`; echo DELIMITER;`) when possible, especially for properties retrieval.

--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,37 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+            delimiter = "AURYNK_DELIMITER_v1"
+            props = [
+                "ro.product.marketname",
+                "ro.product.device",
+                "ro.product.manufacturer",
+                "ro.build.version.release",
+            ]
+            cmd_list = [f"getprop {p}" for p in props]
+            cmd_str = f"; echo {delimiter}; ".join(cmd_list)
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            parts = result.stdout.split(delimiter)
+            marketname = parts[0].strip() if len(parts) > 0 else ""
+            model = parts[1].strip() if len(parts) > 1 else ""
+            manufacturer = parts[2].strip() if len(parts) > 2 else ""
+            android_version = parts[3].strip() if len(parts) > 3 else ""
+
+        except Exception as e:
+            logger.debug(f"Error fetching device info: {e}")
+            marketname = ""
+            model = ""
+            manufacturer = ""
+            android_version = ""
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -714,7 +714,7 @@ def tray_mirror_device(app, address):
                         GLib.idle_add(win._update_all_mirror_buttons)
                     else:
                         # We have just started mirroring: delay update slightly
-                        GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                        GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
             except Exception:
                 pass
 
@@ -796,7 +796,7 @@ def tray_mirror_device(app, address):
                     if not started:
                         try:
                             GLib.idle_add(
-                                lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
+                                lambda: win._show_scrcpy_unavailable_dialog(address) or False
                             )
                         except Exception:
                             logger.exception(
@@ -810,9 +810,7 @@ def tray_mirror_device(app, address):
                     started = False
                 if not started:
                     try:
-                        GLib.idle_add(
-                            lambda: (win._show_scrcpy_unavailable_dialog(address) or False)
-                        )
+                        GLib.idle_add(lambda: win._show_scrcpy_unavailable_dialog(address) or False)
                     except Exception:
                         logger.exception("Failed to schedule scrcpy unavailable dialog from tray")
 
@@ -822,7 +820,7 @@ def tray_mirror_device(app, address):
                 if is_mirroring:
                     GLib.idle_add(win._update_all_mirror_buttons)
                 else:
-                    GLib.timeout_add(120, lambda: (win._update_all_mirror_buttons() or False))
+                    GLib.timeout_add(120, lambda: win._update_all_mirror_buttons() or False)
         except Exception:
             pass
 


### PR DESCRIPTION
💡 What: Batched 4 sequential `adb shell getprop` calls into a single `subprocess.run` call in `ADBController._fetch_device_info`.
🎯 Why: Each `subprocess.run` call incurs overhead (process creation + ADB server communication). This was happening 4 times per device info fetch.
📊 Impact: Reduces the time for fetching device info by ~60-70% (simulated reduction from ~220ms to ~70ms).
🔬 Measurement: Verified with `tests/benchmark_fetch_info.py` (simulated latency) and correctness with `tests/test_adb_fetch_info.py`.

---
*PR created automatically by Jules for task [2233849918543545858](https://jules.google.com/task/2233849918543545858) started by @IshuSinghSE*