### PR TITLE
⚡ Bolt: Batch ADB device info fetch

### DIFF
--- a/aurynk/core/adb_manager.py
+++ b/aurynk/core/adb_manager.py
@@ -268,25 +268,58 @@ class ADBController:
         serial = f"{address}:{connect_port}"
         device_info = {}
 
-        # Helper to run adb shell command
-        def get_prop(prop: str) -> str:
-            try:
-                timeout = SettingsManager().get("adb", "connection_timeout", 10)
-                result = subprocess.run(
-                    [get_adb_path(), "-s", serial, "shell", "getprop", prop],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-                return result.stdout.strip()
-            except Exception:
-                return ""
+        AURYNK_DELIMITER_v1 = "||||"
 
-        # Fetch basic properties
-        marketname = get_prop("ro.product.marketname")
-        model = get_prop("ro.product.device")
-        manufacturer = get_prop("ro.product.manufacturer")
-        android_version = get_prop("ro.build.version.release")
+        try:
+            timeout = SettingsManager().get("adb", "connection_timeout", 10)
+
+            # Construct a single command string to fetch all properties
+            # We use 'echo' to print the delimiter between property values.
+            # This relies on the shell on the device interpreting ';'.
+            # Most Android shells (mksh, toybox) support ';'.
+            cmd_str = (
+                f"getprop ro.product.marketname; echo '{AURYNK_DELIMITER_v1}'; "
+                f"getprop ro.product.device; echo '{AURYNK_DELIMITER_v1}'; "
+                f"getprop ro.product.manufacturer; echo '{AURYNK_DELIMITER_v1}'; "
+                f"getprop ro.build.version.release"
+            )
+
+            # We pass the command string as a single argument after 'shell'
+            # Note: subprocess.run with a list arguments doesn't invoke a shell on the host,
+            # but 'adb shell <cmd>' passes <cmd> to the device's shell.
+            # However, if we pass multiple arguments after 'shell', adb joins them with spaces.
+            # To be safe and precise with our semicolons, we should pass it as one string.
+
+            result = subprocess.run(
+                [get_adb_path(), "-s", serial, "shell", cmd_str],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            if result.returncode != 0:
+                logger.warning(f"Failed to fetch device info: {result.stderr}")
+                marketname = ""
+                model = ""
+                manufacturer = ""
+                android_version = ""
+            else:
+                output = result.stdout
+                parts = output.split(AURYNK_DELIMITER_v1)
+
+                # We expect 4 values separated by 3 delimiters -> 4 parts
+                # Let's clean up each part.
+                marketname = parts[0].strip() if len(parts) > 0 else ""
+                model = parts[1].strip() if len(parts) > 1 else ""
+                manufacturer = parts[2].strip() if len(parts) > 2 else ""
+                android_version = parts[3].strip() if len(parts) > 3 else ""
+
+        except Exception as e:
+            logger.error(f"Error fetching device info: {e}")
+            marketname = ""
+            model = ""
+            manufacturer = ""
+            android_version = ""
 
         device_info["name"] = f"{marketname}" if marketname else (model or _("Unknown"))
         device_info["model"] = model

--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -109,7 +109,7 @@ def start_udev_subscription(app):
 
 # Debounce mechanism to prevent tray update spam
 _last_tray_update = 0
-_tray_update_lock = __import__("threading").Lock()
+_tray_update_lock = threading.Lock()
 _pending_tray_update = None
 _TRAY_UPDATE_MIN_INTERVAL = 0.2  # Minimum 200ms between tray updates
 

--- a/tests/test_adb_manager.py
+++ b/tests/test_adb_manager.py
@@ -61,6 +61,38 @@ class TestADBController(unittest.TestCase):
     @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
     @patch("subprocess.run")
     @patch("aurynk.core.adb_manager.SettingsManager")
+    def test_fetch_device_info(self, mock_settings_manager, mock_subprocess_run, mock_get_adb_path):
+        mock_settings_manager.return_value.get.return_value = 10
+
+        # Combined output
+        # AURYNK_DELIMITER_v1 = "||||"
+        # We need to simulate stdout that contains the delimiter
+        # Format: prop1\nDELIM\nprop2\nDELIM\nprop3\nDELIM\nprop4
+
+        delimiter = "||||"
+        stdout = f"MyPhone\n{delimiter}\nPixel 5\n{delimiter}\nGoogle\n{delimiter}\n12\n"
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=stdout)
+
+        info = self.adb_controller._fetch_device_info("192.168.1.5", 5555)
+
+        self.assertEqual(info["name"], "MyPhone")
+        self.assertEqual(info["model"], "Pixel 5")
+        self.assertEqual(info["manufacturer"], "Google")
+        self.assertEqual(info["android_version"], "12")
+
+        # Verify only 1 subprocess call
+        mock_subprocess_run.assert_called_once()
+        args = mock_subprocess_run.call_args[0][0]
+        self.assertIn("shell", args)
+        # Check command structure
+        cmd_str = args[-1]
+        self.assertIn("getprop ro.product.marketname", cmd_str)
+        self.assertIn("echo '||||'", cmd_str)
+
+    @patch("aurynk.core.adb_manager.get_adb_path", return_value="adb")
+    @patch("subprocess.run")
+    @patch("aurynk.core.adb_manager.SettingsManager")
     @patch("time.sleep")
     def test_pair_device_connect_fail(
         self, mock_sleep, mock_settings_manager, mock_subprocess_run, mock_get_adb_path


### PR DESCRIPTION
⚡ Bolt: Batch ADB device info fetch

💡 **What:** Replaced 4 separate `adb shell getprop` calls in `ADBController._fetch_device_info` with a single batched command using a delimiter.

🎯 **Why:** Fetching device details (name, model, etc.) previously required 4 distinct `subprocess.run` invocations, each incurring overhead for process creation and ADB connection/handshake. This optimization reduces latency when discovering or refreshing devices.

📊 **Impact:** Reduces `subprocess` overhead by 75% for this specific operation (1 call vs 4).

🔬 **Measurement:** Verified using a reproduction script (`tests/repro_perf_adb_info.py`) which confirmed the call count drop from 4 to 1. Full unit test suite passed.

---
*PR created automatically by Jules for task [5609778613068306962](https://jules.google.com/task/5609778613068306962) started by @IshuSinghSE*