### PR TITLE
⚡ Bolt: Resolve N+1 adb devices bottleneck for faster UI rendering

### DIFF
--- a/aurynk/services/tray_service.py
+++ b/aurynk/services/tray_service.py
@@ -192,7 +192,9 @@ def _do_tray_update(app, status: str = None):
 
         devices = win.adb_controller.load_paired_devices()
         device_status = []
-        from aurynk.utils.adb_utils import is_device_connected
+        from aurynk.utils.adb_utils import get_connected_device_serials
+
+        connected_serials = get_connected_device_serials()
 
         scrcpy = ScrcpyManager()
         # Query helper for running processes (non-blocking small timeout)
@@ -222,9 +224,9 @@ def _do_tray_update(app, status: str = None):
                     mirroring = False
 
                     if address and connect_port:
-                        connected = is_device_connected(address, connect_port)
-                        # Prefer helper process status when available
                         key = f"{address}:{connect_port}"
+                        connected = key in connected_serials
+                        # Prefer helper process status when available
                         mirroring = False
                         if key in helper_processes:
                             mirroring = True
@@ -259,7 +261,8 @@ def _do_tray_update(app, status: str = None):
                 connected = False
                 mirroring = False
                 if address and connect_port:
-                    connected = is_device_connected(address, connect_port)
+                    key = f"{address}:{connect_port}"
+                    connected = key in connected_serials
                     mirroring = scrcpy.is_mirroring(address, connect_port)
                 device_status.append(
                     {
@@ -343,11 +346,15 @@ def send_devices_to_tray(devices):
     import subprocess
 
     try:
-        from aurynk.utils.adb_utils import is_device_connected
+        from aurynk.utils.adb_utils import get_connected_device_serials, is_device_connected
+
+        connected_serials = get_connected_device_serials()
     except Exception:
         # If import fails, fallback to assuming devices are disconnected
         def is_device_connected(a, p):
             return False
+
+        connected_serials = set()
 
     from aurynk.core.scrcpy_runner import ScrcpyManager
 
@@ -371,7 +378,8 @@ def send_devices_to_tray(devices):
         mirroring = False
         if address and connect_port:
             try:
-                connected = is_device_connected(address, connect_port)
+                key = f"{address}:{connect_port}"
+                connected = key in connected_serials
                 mirroring = scrcpy.is_mirroring(address, connect_port)
             except Exception:
                 connected = False

--- a/aurynk/ui/windows/main_window.py
+++ b/aurynk/ui/windows/main_window.py
@@ -642,10 +642,15 @@ class AurynkWindow(Adw.ApplicationWindow):
             self.wireless_group.remove(row)
         self._wireless_rows = []
 
+        # Fetch connected serials once for fast batch lookup
+        from aurynk.utils.adb_utils import get_connected_device_serials
+
+        connected_serials = get_connected_device_serials()
+
         # Add device rows
         if devices:
             for device in devices:
-                device_row = self._create_device_row(device)
+                device_row = self._create_device_row(device, connected_serials=connected_serials)
                 self.wireless_group.add(device_row)
                 self._wireless_rows.append(device_row)
         else:
@@ -1043,7 +1048,7 @@ class AurynkWindow(Adw.ApplicationWindow):
         #     f"Final USB dev_data for {adb_serial}: name='{dev_data.get('name')}', manufacturer='{dev_data.get('manufacturer')}', model='{dev_data.get('model')}', android_version='{dev_data.get('android_version')}'"
         # )
 
-    def _create_device_row(self, device, is_usb=False):
+    def _create_device_row(self, device, is_usb=False, connected_serials=None):
         """Create a row widget for a device."""
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         row.set_margin_start(24)
@@ -1124,7 +1129,11 @@ class AurynkWindow(Adw.ApplicationWindow):
             connect_port = device.get("connect_port")
             connected = False
             if address and connect_port:
-                connected = is_device_connected(address, connect_port)
+                serial_key = f"{address}:{connect_port}"
+                if connected_serials is not None:
+                    connected = serial_key in connected_serials
+                else:
+                    connected = is_device_connected(address, connect_port)
             if connected:
                 status_btn.set_label(_("Disconnect"))
                 status_btn.add_css_class("destructive-action")
@@ -1163,7 +1172,11 @@ class AurynkWindow(Adw.ApplicationWindow):
             connect_port = device.get("connect_port")
             connected = False
             if address and connect_port:
-                connected = is_device_connected(address, connect_port)
+                serial_key = f"{address}:{connect_port}"
+                if connected_serials is not None:
+                    connected = serial_key in connected_serials
+                else:
+                    connected = is_device_connected(address, connect_port)
             mirror_btn.set_sensitive(connected)
             if connected:
                 # Check if already mirroring and set appropriate style
@@ -1501,7 +1514,9 @@ class AurynkWindow(Adw.ApplicationWindow):
         """Update only mirror button states without rebuilding UI.
         This is called when tray triggers mirroring to sync main window."""
         scrcpy = self._get_scrcpy_manager()
-        from aurynk.utils.adb_utils import is_device_connected
+        from aurynk.utils.adb_utils import get_connected_device_serials
+
+        connected_serials = get_connected_device_serials()
 
         # Update wireless device rows
         if hasattr(self, "_wireless_rows"):
@@ -1530,7 +1545,8 @@ class AurynkWindow(Adw.ApplicationWindow):
                         if mirror_btn:
                             connected = False
                             if address and connect_port:
-                                connected = is_device_connected(address, connect_port)
+                                serial_key = f"{address}:{connect_port}"
+                                connected = serial_key in connected_serials
 
                             mirror_btn.set_sensitive(connected)
                             if connected:

--- a/aurynk/utils/adb_utils.py
+++ b/aurynk/utils/adb_utils.py
@@ -15,6 +15,25 @@ def get_adb_path():
     return "adb"
 
 
+def get_connected_device_serials() -> set[str]:
+    """Get a set of all currently connected device serials.
+    This helps prevent the N+1 problem of repeatedly calling 'adb devices'."""
+    import subprocess
+
+    serials = set()
+
+    try:
+        result = subprocess.run([get_adb_path(), "devices"], capture_output=True, text=True)
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if "\tdevice" in line:
+                    serial = line.split("\t")[0]
+                    serials.add(serial)
+    except Exception:
+        pass
+    return serials
+
+
 def is_device_connected(address, connect_port):
     """Check if a device is connected via adb."""
     import subprocess


### PR DESCRIPTION
## ⚡ Bolt: Resolve N+1 adb devices bottleneck for faster UI rendering

### 💡 What
Implemented a new helper `get_connected_device_serials()` in `aurynk/utils/adb_utils.py` that fetches all ADB connected serials exactly once. Then updated the main window list rendering and the tray service status updates to use this set for O(1) loop lookups instead of invoking `is_device_connected()` inside loops.

### 🎯 Why
Iterating over paired devices and calling `is_device_connected` for each executed a separate `adb devices` subprocess call. This N+1 problem severely blocked the main GTK thread and slowed down rendering during UI updates.

### 📊 Impact
O(N) subprocess calls are reduced to exactly 1 subprocess call per list rendering or tray update. This prevents main thread stalls and enables faster load/refresh times for the device list.

### 🔬 Measurement
Run the application with multiple paired devices; device list refreshing and tray menu updating should no longer cause observable stuttering.

---
*PR created automatically by Jules for task [13861166056712928620](https://jules.google.com/task/13861166056712928620) started by @IshuSinghSE*