### PR TITLE
Reorder Keyboard Shortcuts item in menu

### DIFF
--- a/data/ui/main_window.ui
+++ b/data/ui/main_window.ui
@@ -7,14 +7,14 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
-        <attribute name="action">win.shortcuts</attribute>
-        <attribute name="accel">&lt;Primary&gt;question</attribute>
-      </item>
-      <item>
         <attribute name="label" translatable="yes">_Preferences</attribute>
         <attribute name="action">win.preferences</attribute>
         <attribute name="accel">&lt;Primary&gt;comma</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+        <attribute name="action">win.shortcuts</attribute>
+        <attribute name="accel">&lt;Primary&gt;question</attribute>
       </item>
     </section>
     <section>


### PR DESCRIPTION
Reorder it in the same order as other GNOME applications such as Calculator, Camera, Console and Text Editor.