### PR TITLE
Change "About" to "About Aurynk"

### DIFF
--- a/data/ui/main_window.ui
+++ b/data/ui/main_window.ui
@@ -19,7 +19,7 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">_About</attribute>
+        <attribute name="label" translatable="yes">_About Aurynk</attribute>
         <attribute name="action">win.about</attribute>
       </item>
     </section>


### PR DESCRIPTION
In GNOME applications the name is included in the "About" menu.

Example, "About Console" and "About Text Editor".